### PR TITLE
Removed default airflow config

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -51,7 +51,8 @@ module "mwaa" {
       log_level = "INFO"
     }
   }
-  airflow_configuration_options = {
+
+  airflow_configuration_options = { # Checkout the suggested Airflow configurations under https://docs.aws.amazon.com/mwaa/latest/userguide/configuring-env-variables.html
     "core.default_task_retries"            = 3
     "celery.worker_autoscale"              = "5,5"
     "core.check_slas"                      = "false"
@@ -66,11 +67,12 @@ module "mwaa" {
     "web_server.web_server_master_timeout" = 480
     "web_server.web_server_worker_timeout" = 480
   }
-  min_workers           = 1
-  max_workers           = 25
-  vpc_id                = module.vpc.vpc_id
-  private_subnet_ids    = module.vpc.private_subnets
-  webserver_access_mode = "PUBLIC_ONLY"   # Change this to PRIVATE_ONLY for production environments
+  min_workers        = 1
+  max_workers        = 25
+  vpc_id             = module.vpc.vpc_id
+  private_subnet_ids = module.vpc.private_subnets
+
+  webserver_access_mode = "PUBLIC_ONLY"   # Choose the Private network option(PRIVATE_ONLY) if your Apache Airflow UI is only accessed within a corporate network, and you do not require access to public repositories for web server requirements installation
   source_cidr           = ["10.1.0.0/16"] # Add your IP here to access Airflow UI
 
   # create_security_group = true # change to to `false` to bring your sec group using `security_group_ids`

--- a/locals.tf
+++ b/locals.tf
@@ -6,19 +6,7 @@ locals {
   source_bucket_arn = var.source_bucket_arn != null ? var.source_bucket_arn : aws_s3_bucket.mwaa[0].arn
 
   default_airflow_configuration_options = {
-    "core.default_task_retries"            = 3
-    "celery.worker_autoscale"              = "5,5"
-    "core.check_slas"                      = "false"
-    "core.dag_concurrency"                 = 96
-    "core.dag_file_processor_timeout"      = 600
-    "core.dagbag_import_timeout"           = 600
-    "core.max_active_runs_per_dag"         = 32
-    "core.parallelism"                     = 64
-    "scheduler.processor_poll_interval"    = 15
-    "logging.logging_level"                = "INFO"
-    "core.dag_file_processor_timeout"      = 120
-    "web_server.web_server_master_timeout" = 480
-    "web_server.web_server_worker_timeout" = 480
+    "logging.logging_level" = "INFO"
   }
 
   airflow_configuration_options = merge(local.default_airflow_configuration_options, var.airflow_configuration_options)


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

- Removed default airflow config from `locals.tf`
- Examples still use some defaults to show the users

### Motivation

<!-- What inspired you to submit this pull request? -->


### More
- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
