### PR TITLE
fix: Remove AWS provider version restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ Apache-2.0 Licensed. See [LICENSE](https://github.com/aws-ia/terraform-aws-mwaa/
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.20.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.20.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.20 |
 
 ## Modules
 

--- a/examples/basic/providers.tf
+++ b/examples/basic/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.20.0"
+      version = ">= 4.20"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.20.0"
+      version = ">= 4.20"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

Removes the restriction that only allowed patch releases of `4.20` version to allow all releases above 4.20.


### Motivation

Fixes #21 


### More
- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [X] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
