### PR TITLE
Fix failing ACL creation for new buckets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -108,13 +108,6 @@ resource "aws_s3_bucket" "mwaa" {
   tags          = var.tags
 }
 
-resource "aws_s3_bucket_acl" "mwaa" {
-  count = var.create_s3_bucket ? 1 : 0
-
-  bucket = aws_s3_bucket.mwaa[0].id
-  acl    = "private"
-}
-
 #tfsec:ignore:aws-s3-encryption-customer-key
 resource "aws_s3_bucket_server_side_encryption_configuration" "mwaa" {
   count = var.create_s3_bucket ? 1 : 0


### PR DESCRIPTION
### What does this PR do?

Fixes failing resource creation for new stacks. 


### Motivation

S3 recently rolled out announced security changes:
https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

This leads to a failure in creating ACLs on new buckets:

```
Error: error creating S3 bucket ACL for mwaa-873745192490-20230512083935451100000003: AccessControlListNotSupported: The bucket does not allow ACLs
│       status code: 400, request id: BFZ83R62VQJDJ69M, host id: V2hf9aZQz3k1gIxYrNAY4XThAfJ19Dl3hxah/PLRMPx4CUdD5EWHPjq9paz1r8/txamhjmRy4hACgLYWrp9VyQ==
│ 
│   with module.mwaa.aws_s3_bucket_acl.mwaa[0],
│   on .terraform/modules/mwaa/main.tf line 109, in resource "aws_s3_bucket_acl" "mwaa":
│  109: resource "aws_s3_bucket_acl" "mwaa" {
```


### More
- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

This should not cause problems for existing buckets either, as the ACL resource re-implements the default behavior (see https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl).
