### PR TITLE
Remove s3 arn variable as a requirement

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -4,6 +4,10 @@ data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
+data "aws_s3_bucket" "selected" {
+  bucket = var.source_bucket_name
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # MWAA Role
 # ---------------------------------------------------------------------------------------------------------------------
@@ -58,8 +62,8 @@ data "aws_iam_policy_document" "mwaa" {
       "s3:*"
     ]
     resources = [
-      local.source_bucket_arn,
-      "${local.source_bucket_arn}/*"
+      data.aws_s3_bucket.selected.arn,
+      "${data.aws_s3_bucket.selected.arn}/*"
     ]
   }
 

--- a/locals.tf
+++ b/locals.tf
@@ -3,7 +3,7 @@ locals {
 
   security_group_ids = var.create_security_group ? concat([aws_security_group.mwaa[0].id], var.security_group_ids) : var.security_group_ids
 
-  source_bucket_arn = var.create_s3_bucket ? aws_s3_bucket.mwaa[0].arn : var.source_bucket_arn
+  source_bucket_arn = var.create_s3_bucket ? aws_s3_bucket.mwaa[0].arn : data.aws_s3_bucket.selected.arn
 
   default_airflow_configuration_options = {
     "logging.logging_level" = "INFO"

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "aws_mwaa_environment" "mwaa" {
   execution_role_arn               = local.execution_role_arn
   airflow_configuration_options    = local.airflow_configuration_options
 
-  source_bucket_arn               = local.source_bucket_arn
+  source_bucket_arn               = data.aws_s3_bucket.selected.arn
   webserver_access_mode           = var.webserver_access_mode
   weekly_maintenance_window_start = var.weekly_maintenance_window_start
 

--- a/variables.tf
+++ b/variables.tf
@@ -206,11 +206,11 @@ variable "source_bucket_name" {
   default     = null
 }
 
-variable "source_bucket_arn" {
-  description = "(Required) The Amazon Resource Name (ARN) of your Amazon S3 storage bucket. For example, arn:aws:s3:::airflow-mybucketname"
-  type        = string
-  default     = null
-}
+#variable "source_bucket_arn" {
+#  description = "(Required) The Amazon Resource Name (ARN) of your Amazon S3 storage bucket. For example, arn:aws:s3:::airflow-mybucketname"
+#  type        = string
+#  default     = null
+#}
 
 #----------------------------------------------------------------
 # MWAA Security groups


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
remove need of s3 arn variable, the data module provides the capability to get s3 arn from S3 Bucket Name

### Motivation

<!-- What inspired you to submit this pull request? -->
This pull request will improve usage of MWAA Module

### More
- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
