### PR TITLE
KMS policy to accept customer managed KMS keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ No modules.
 | [aws_iam_role_policy_attachment.mwaa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_mwaa_environment.mwaa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/mwaa_environment) | resource |
 | [aws_s3_bucket.mwaa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_acl.mwaa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_public_access_block.mwaa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.mwaa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.mwaa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
@@ -139,7 +138,7 @@ No modules.
 | <a name="input_environment_class"></a> [environment\_class](#input\_environment\_class) | (Optional) Environment class for the cluster. Possible options are mw1.small, mw1.medium, mw1.large.<br>Will be set by default to mw1.small. Please check the AWS Pricing for more information about the environment classes. | `string` | `"mw1.small"` | no |
 | <a name="input_execution_role_arn"></a> [execution\_role\_arn](#input\_execution\_role\_arn) | (Required) The Amazon Resource Name (ARN) of the task execution role that the Amazon MWAA and its environment can assume<br>Mandatory if `create_iam_role=false` | `string` | `null` | no |
 | <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | IAM role Force detach policies | `bool` | `false` | no |
-| <a name="input_iam_role_additional_policies"></a> [iam\_role\_additional\_policies](#input\_iam\_role\_additional\_policies) | A map of additional policy ARNs to be added to the IAM role, with an arbitary key name | `map(string)` | `{}` | no |
+| <a name="input_iam_role_additional_policies"></a> [iam\_role\_additional\_policies](#input\_iam\_role\_additional\_policies) | Additional policies to be added to the IAM role | `map(string)` | `{}` | no |
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | IAM Role Name to be created if execution\_role\_arn is null | `string` | `null` | no |
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | IAM role path | `string` | `"/"` | no |
 | <a name="input_iam_role_permissions_boundary"></a> [iam\_role\_permissions\_boundary](#input\_iam\_role\_permissions\_boundary) | IAM role Permission boundary | `string` | `null` | no |

--- a/data.tf
+++ b/data.tf
@@ -124,7 +124,7 @@ data "aws_iam_policy_document" "mwaa" {
       condition {
         test     = "StringLike"
         variable = "kms:ViaService"
-  
+
         values = [
           "sqs.${data.aws_region.current.name}.amazonaws.com"
         ]
@@ -148,7 +148,7 @@ data "aws_iam_policy_document" "mwaa" {
       condition {
         test     = "StringLike"
         variable = "kms:ViaService"
-  
+
         values = [
           "sqs.${data.aws_region.current.name}.amazonaws.com"
         ]

--- a/data.tf
+++ b/data.tf
@@ -129,6 +129,54 @@ data "aws_iam_policy_document" "mwaa" {
     }
   }
 
+  dynamic "statement" {
+    for_each = var.kms_key != null ? [] : [1]
+    content {
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:GenerateDataKey*",
+        "kms:Encrypt"
+      ]
+      not_resources = [
+        "arn:${data.aws_partition.current.id}:kms:*:${data.aws_caller_identity.current.account_id}:key/*"
+      ]
+      condition {
+        test     = "StringLike"
+        variable = "kms:ViaService"
+  
+        values = [
+          "sqs.${data.aws_region.current.name}.amazonaws.com"
+        ]
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.kms_key != null ? [1] : []
+    content {
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt",
+        "kms:DescribeKey",
+        "kms:GenerateDataKey*",
+        "kms:Encrypt"
+      ]
+      resources = [
+        var.var.kms_key
+      ]
+      condition {
+        test     = "StringLike"
+        variable = "kms:ViaService"
+  
+        values = [
+          "sqs.${data.aws_region.current.name}.amazonaws.com"
+        ]
+      }
+    }
+  }
+
   statement {
     effect = "Allow"
     actions = [

--- a/data.tf
+++ b/data.tf
@@ -108,27 +108,6 @@ data "aws_iam_policy_document" "mwaa" {
     ]
   }
 
-  statement {
-    effect = "Allow"
-    actions = [
-      "kms:Decrypt",
-      "kms:DescribeKey",
-      "kms:GenerateDataKey*",
-      "kms:Encrypt"
-    ]
-    not_resources = [
-      "arn:${data.aws_partition.current.id}:kms:*:${data.aws_caller_identity.current.account_id}:key/*"
-    ]
-    condition {
-      test     = "StringLike"
-      variable = "kms:ViaService"
-
-      values = [
-        "sqs.${data.aws_region.current.name}.amazonaws.com"
-      ]
-    }
-  }
-
   dynamic "statement" {
     for_each = var.kms_key != null ? [] : [1]
     content {

--- a/data.tf
+++ b/data.tf
@@ -143,7 +143,7 @@ data "aws_iam_policy_document" "mwaa" {
         "kms:Encrypt"
       ]
       resources = [
-        var.var.kms_key
+        var.kms_key
       ]
       condition {
         test     = "StringLike"


### PR DESCRIPTION
### What does this PR do?
Currently the policy doesn't not work with customer managed KMS keys even through the module accepts them. This ill be a no-op for existing users but will allow users with their own KMS keys to be able to use this module.


### Motivation
I have an customer managed key and noticed this was not working 

### More
- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
