### PR TITLE
bump vpc module to use v5 + Add Terratest scripts

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -25,9 +25,17 @@ resource "aws_s3_bucket" "this" {
   tags   = var.tags
 }
 
-resource "aws_s3_bucket_acl" "this" {
+resource "aws_s3_bucket_ownership_controls" "this" {
   bucket = aws_s3_bucket.this.id
-  acl    = "private"
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "this" {
+  depends_on = [aws_s3_bucket_ownership_controls.this]
+  bucket     = aws_s3_bucket.this.id
+  acl        = "private"
 }
 
 resource "aws_s3_bucket_versioning" "this" {
@@ -141,7 +149,7 @@ module "mwaa" {
 #---------------------------------------------------------------
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = "~> 5.0"
 
   name = var.name
   cidr = var.vpc_cidr

--- a/test/mwaa_terratest.go
+++ b/test/mwaa_terratest.go
@@ -1,1 +1,0 @@
-// TODO Work in Progress

--- a/test/mwaa_test.go
+++ b/test/mwaa_test.go
@@ -1,0 +1,21 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+func TestExamplesBasic(t *testing.T) {
+
+	terraformOptions := &terraform.Options{
+		TerraformDir: "../examples/basic",
+		// Vars: map[string]interface{}{
+		// 	"myvar":     "test",
+		// 	"mylistvar": []string{"list_item_1"},
+		// },
+	}
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApply(t, terraformOptions)
+}


### PR DESCRIPTION
### What does this PR do?
bump vpc module to use v5 to fix https://github.com/hashicorp/terraform/issues/31730
adding aws_s3_bucket_ownership_controls resource to fix https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/223

<!-- A brief description of the change being made with this pull request. -->
Overcome deprecation warnings 

### Motivation

<!-- What inspired you to submit this pull request? -->
Errors being faced when running the basic example

### More
- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

```
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

mwaa_arn = "arn:aws:airflow:eu-west-1:XXXXXXXXX:environment/basic-mwaa"
mwaa_role_arn = "arn:aws:iam::XXXXXXXXX:role/mwaa-executor20230925061623422400000001"
mwaa_security_group_id = "sg-XXXXXXXXX"
mwaa_service_role_arn = "arn:aws:iam::XXXXXXXXX:role/aws-service-role/airflow.amazonaws.com/AWSServiceRoleForAmazonMWAA"
mwaa_status = "AVAILABLE"
mwaa_webserver_url = "XXXXXXXXX.eu-west-1.airflow.amazonaws.com"
```

<!-- Anything else we should know when reviewing? -->
