### PR TITLE
Delete mwaa resource lifecycle block with ignore changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,13 +57,6 @@ resource "aws_mwaa_environment" "mwaa" {
       log_level = try(var.logging_configuration.worker_logs.log_level, "CRITICAL")
     }
   }
-
-  lifecycle {
-    ignore_changes = [
-      plugins_s3_object_version,
-      requirements_s3_object_version
-    ]
-  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### What does this PR do?

This PR deletes lifecycle block from MWAA resource in order to update MWAA whenever requirements or plugins objects version changes.

### Motivation

Motivation is to avoid restarting MWAA manually after update in requirements.txt or plugins.


### More
- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
