### PR TITLE
Ignore changes made to MWAA Startup script version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,8 @@ resource "aws_mwaa_environment" "mwaa" {
   lifecycle {
     ignore_changes = [
       plugins_s3_object_version,
-      requirements_s3_object_version
+      requirements_s3_object_version,
+      startup_script_s3_object_version
     ]
   }
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds the lifecycle ignore_changes block for the MWAA startup script version.
This prevents updating / modifying the existing deployment when there are changes made to the start-up script.



### Motivation

<!-- What inspired you to submit this pull request? -->

Our deployments for the requirements / plugins etc. do not lead to our MWAA environment requiring an update, we noticed an issue when there were changes to the start-up script.


### More
- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
