### PR TITLE
add describecluster

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -86,7 +86,8 @@ data "aws_iam_policy_document" "mwaa" {
     actions = [
       "logs:DescribeLogGroups",
       "cloudwatch:PutMetricData",
-      "s3:GetAccountPublicAccessBlock"
+      "s3:GetAccountPublicAccessBlock",
+      "eks:DescribeCluster"
     ]
     resources = [
       "*"


### PR DESCRIPTION
see https://github.com/Almenon/terraform-aws-mwaa/pull/2 and https://github.com/aws-ia/terraform-aws-mwaa/issues/53 (which just links to first link)


### What does this PR do?

Adds describe cluster permission. It's a read-only operation so it's relatively safe even against `*`.
Resolves #53 


### Motivation

<!-- What inspired you to submit this pull request? -->


### More
- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [ ] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

<!-- Anything else we should know when reviewing? -->
