### PR TITLE
[sc-195333] Remove ignore changes on requirements and  startup_script versioning

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @aws-ia/aws-ia @vara-bonthu
+* @sagansystems/platform

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sagansystems/platform
+* @aws-ia/aws-ia @vara-bonthu

--- a/main.tf
+++ b/main.tf
@@ -57,14 +57,6 @@ resource "aws_mwaa_environment" "mwaa" {
       log_level = try(var.logging_configuration.worker_logs.log_level, "CRITICAL")
     }
   }
-
-  lifecycle {
-    ignore_changes = [
-      plugins_s3_object_version,
-      requirements_s3_object_version,
-      startup_script_s3_object_version
-    ]
-  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
# What
Remove ignore changes on requirements and  startup_script versioning.

# Why
We are not keeping old versions of requirements and  startup_script versioning, which causes airflow terraform plan fail.

# Testing
- Use this forked module without ignore block.
- Test tf plan/apply from airflow workspace
