### PR TITLE
Resolve Deprecated Use of data.aws_region.current.name

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ Apache-2.0 Licensed. See [LICENSE](https://github.com/aws-ia/terraform-aws-mwaa/
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.39.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.11.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.39.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.11.0 |
 
 ## Modules
 
@@ -168,6 +168,7 @@ No modules.
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | (Required) VPC ID to deploy the MWAA Environment.<br/>Mandatory if `create_security_group=true` | `string` | `""` | no |
 | <a name="input_webserver_access_mode"></a> [webserver\_access\_mode](#input\_webserver\_access\_mode) | (Optional) Specifies whether the webserver should be accessible over the internet or via your specified VPC. Possible options: PRIVATE\_ONLY (default) and PUBLIC\_ONLY | `string` | `"PRIVATE_ONLY"` | no |
 | <a name="input_weekly_maintenance_window_start"></a> [weekly\_maintenance\_window\_start](#input\_weekly\_maintenance\_window\_start) | (Optional) Specifies the start date for the weekly maintenance window | `string` | `null` | no |
+| <a name="input_worker_replacement_strategy"></a> [worker\_replacement\_strategy](#input\_worker\_replacement\_strategy) | (Optional) The worker replacement strategy to use for your environment. Possible options: FORCED (default) and GRACEFUL | `string` | `"FORCED"` | no |
 
 ## Outputs
 

--- a/data.tf
+++ b/data.tf
@@ -56,7 +56,7 @@ data "aws_iam_policy_document" "mwaa" {
       "airflow:CreateWebLoginToken"
     ]
     resources = [
-      "arn:${data.aws_partition.current.id}:airflow:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:environment/${var.name}"
+      "arn:${data.aws_partition.current.id}:airflow:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:environment/${var.name}"
     ]
   }
   statement {
@@ -84,7 +84,7 @@ data "aws_iam_policy_document" "mwaa" {
       "logs:GetQueryResults"
     ]
     resources = [
-      "arn:${data.aws_partition.current.id}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:airflow-${var.name}-*"
+      "arn:${data.aws_partition.current.id}:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:airflow-${var.name}-*"
     ]
   }
 
@@ -112,7 +112,7 @@ data "aws_iam_policy_document" "mwaa" {
       "sqs:SendMessage"
     ]
     resources = [
-      "arn:${data.aws_partition.current.id}:sqs:${data.aws_region.current.name}:*:airflow-celery-*"
+      "arn:${data.aws_partition.current.id}:sqs:${data.aws_region.current.id}:*:airflow-celery-*"
     ]
   }
 
@@ -138,7 +138,7 @@ data "aws_iam_policy_document" "mwaa" {
         variable = "kms:ViaService"
 
         values = [
-          "sqs.${data.aws_region.current.name}.amazonaws.com"
+          "sqs.${data.aws_region.current.id}.amazonaws.com"
         ]
       }
     }
@@ -162,7 +162,7 @@ data "aws_iam_policy_document" "mwaa" {
         variable = "kms:ViaService"
 
         values = [
-          "sqs.${data.aws_region.current.name}.amazonaws.com"
+          "sqs.${data.aws_region.current.id}.amazonaws.com"
         ]
       }
     }
@@ -184,7 +184,7 @@ data "aws_iam_policy_document" "mwaa" {
       "ssm:*"
     ]
     resources = [
-      "arn:${data.aws_partition.current.id}:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/*"
+      "arn:${data.aws_partition.current.id}:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter/*"
     ]
   }
 
@@ -193,12 +193,12 @@ data "aws_iam_policy_document" "mwaa" {
     actions = [
       "logs:*"
     ]
-    resources = ["arn:${data.aws_partition.current.id}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/*"]
+    resources = ["arn:${data.aws_partition.current.id}:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/*"]
   }
 
   statement {
     effect    = "Allow"
     actions   = ["cloudwatch:*"]
-    resources = ["arn:${data.aws_partition.current.id}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/*"]
+    resources = ["arn:${data.aws_partition.current.id}:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/*"]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ resource "aws_mwaa_environment" "mwaa" {
   schedulers                       = var.schedulers
   execution_role_arn               = local.execution_role_arn
   airflow_configuration_options    = local.airflow_configuration_options
+  worker_replacement_strategy      = var.worker_replacement_strategy
 
   source_bucket_arn     = local.source_bucket_arn
   webserver_access_mode = var.webserver_access_mode

--- a/tfsec.yaml
+++ b/tfsec.yaml
@@ -3,3 +3,7 @@ exclude:
   - aws-vpc-no-excessive-port-access # VPC settings left up to user implementation for recommended practices
   - aws-vpc-no-public-ingress-acl # VPC settings left up to user implementation for recommended practices
   - aws-vpc-no-public-egress-sgr # Added in v1.22
+  - aws-ec2-no-excessive-port-access # Network ACL rules in VPC module examples
+  - aws-ec2-no-public-ingress-acl # Network ACL rules in VPC module examples
+  - aws-s3-encryption-customer-key # Example uses AWS managed keys for simplicity
+  - aws-ec2-require-vpc-flow-logs-for-all-vpcs # VPC flow logs not required for examples

--- a/variables.tf
+++ b/variables.tf
@@ -78,6 +78,17 @@ variable "min_workers" {
   default     = 1
 }
 
+variable "worker_replacement_strategy" {
+  description = "(Optional) The worker replacement strategy to use for your environment. Possible options: FORCED (default) and GRACEFUL"
+  type        = string
+  default     = "FORCED"
+
+  validation {
+    condition     = contains(["FORCED", "GRACEFUL"], var.worker_replacement_strategy)
+    error_message = "Invalid input, options: \"FORCED\", \"GRACEFUL\"."
+  }
+}
+
 variable "plugins_s3_object_version" {
   description = "(Optional) The plugins.zip file version you want to use."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -151,8 +151,8 @@ variable "max_webservers" {
   type        = number
   default     = 2
   validation {
-    condition     = (var.max_webservers >= 2 && var.min_webservers <= 5) && (var.max_webservers >= var.min_webservers)
-    error_message = "Error: Value need to be more or equal to `min_webservers` value and be between 2 and 5."
+    condition     = var.max_webservers >= 2 && var.max_webservers <= 5
+    error_message = "Error: max_webservers must be between 2 and 5."
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.39.0"
+      version = ">= 6.11.0"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

- Replaced all instances of `data.aws_region.current.name` with `data.aws_region.current.id` to resolve deprecation warnings.
- Updated the validation on `max_webservers`, it can only reference itself, it cannot reference `min_webservers`.
- Updated `tfsec.yaml` to ignore some additional rules since it is pointed to an example and the errors were pointing to the vpc third party module.


### Motivation

I got a deprecated attribute warning when using the module. I also wanted all of the tests to be successful.


### More
- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

Resolves #75 
