### PR TITLE
fix: update variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -117,10 +117,10 @@ variable "startup_script_s3_path" {
 variable "schedulers" {
   description = "(Optional) The number of schedulers that you want to run in your environment."
   type        = number
-  default     = 2
+  default     = 1
   validation {
-    condition     = var.schedulers >= 2 && var.schedulers <= 5
-    error_message = "Error: Value need to be between 2 and 5."
+    condition     = var.schedulers >= 1 && var.schedulers <= 5
+    error_message = "Error: Value need to be between 1 and 5."
   }
 
 }
@@ -139,10 +139,10 @@ variable "webserver_access_mode" {
 variable "min_webservers" {
   description = "(Optional) The minimum number of webserver instances that you want to run in your environment."
   type        = number
-  default     = 2
+  default     = 1
   validation {
-    condition     = var.min_webservers >= 2 && var.min_webservers <= 5
-    error_message = "Error: Value need to be between 2 and 5."
+    condition     = var.min_webservers >= 1 && var.min_webservers <= 5
+    error_message = "Error: Value need to be between 1 and 5."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -151,7 +151,7 @@ variable "max_webservers" {
   type        = number
   default     = 2
   validation {
-    condition     = (var.max_webservers >= 2 && var.min_webservers <= 5) && (var.max_webservers >= var.min_webservers)
+    condition     = (var.max_webservers >= 1 && var.min_webservers <= 5) && (var.max_webservers >= var.min_webservers)
     error_message = "Error: Value need to be more or equal to `min_webservers` value and be between 2 and 5."
   }
 }


### PR DESCRIPTION
### What does this PR do?

Changed min_webservers and scheduler validation rule to include min 1 node based on AWS micro instance configuration.


### Motivation

AWS added micro instance for MWAA. MWAA micro instance requires min one node for different components of airflow including webserver and scheduler. This AWS terraform module need updates to its validation rule in order to incorporate the change.

