### PR TITLE
fix: mw1.micro validation constraints for schedulers, webservers, workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,36 @@ module "mwaa" {
 }
 ```
 
+## Environment Class Constraints
+
+The `mw1.micro` environment class has fixed capacity constraints that differ from other classes:
+
+| Parameter | mw1.micro | mw1.small and above |
+|-----------|-----------|---------------------|
+| `schedulers` | Must be `1` | `2` to `5` |
+| `min_webservers` | Must be `1` | `2` to `5` |
+| `max_webservers` | Must be `1` | `2` to `5` |
+| `min_workers` | Must be `1` | `1` to `25` |
+| `max_workers` | Must be `1` | `1` to `25` |
+
+When using `mw1.micro`, you must explicitly set these values to `1`:
+
+```hcl
+module "mwaa" {
+  source = "aws-ia/mwaa/aws"
+
+  environment_class = "mw1.micro"
+  schedulers        = 1
+  min_webservers    = 1
+  max_webservers    = 1
+  min_workers       = 1
+  max_workers       = 1
+  # ...
+}
+```
+
+For more details, see the [AWS MWAA environment class documentation](https://docs.aws.amazon.com/mwaa/latest/userguide/environment-class.html).
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
@@ -90,7 +120,7 @@ Apache-2.0 Licensed. See [LICENSE](https://github.com/aws-ia/terraform-aws-mwaa/
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.39.0 |
 
 ## Providers
@@ -137,7 +167,7 @@ No modules.
 | <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Create security group for MWAA | `bool` | `true` | no |
 | <a name="input_dag_s3_path"></a> [dag\_s3\_path](#input\_dag\_s3\_path) | (Required) The relative path to the DAG folder on your Amazon S3 storage bucket. For example, dags. | `string` | `"dags"` | no |
 | <a name="input_endpoint_management"></a> [endpoint\_management](#input\_endpoint\_management) | (Optional) Specifies who is responsible for creating the VPC endpoints for environment. CUSTOMER is useful when your VPC is owned by another account. Possible options: SERVICE (default) and CUSTOMER | `string` | `"SERVICE"` | no |
-| <a name="input_environment_class"></a> [environment\_class](#input\_environment\_class) | (Optional) Environment class for the cluster. Possible options are mw1.micro, mw1.small, mw1.medium, mw1.large, mw1.xlarge, mw1.2xlarge.<br/>Will be set by default to mw1.micro. Please check the AWS Pricing for more information about the environment classes. | `string` | `"mw1.micro"` | no |
+| <a name="input_environment_class"></a> [environment\_class](#input\_environment\_class) | (Optional) Environment class for the cluster. Possible options are mw1.micro, mw1.small, mw1.medium, mw1.large, mw1.xlarge, mw1.2xlarge.<br/>Will be set by default to mw1.small. Please check the AWS Pricing for more information about the environment classes.<br/>Note: mw1.micro has fixed capacity constraints — schedulers, webservers, and workers must all be set to 1. | `string` | `"mw1.small"` | no |
 | <a name="input_execution_role_arn"></a> [execution\_role\_arn](#input\_execution\_role\_arn) | (Required) The Amazon Resource Name (ARN) of the task execution role that the Amazon MWAA and its environment can assume<br/>Mandatory if `create_iam_role=false` | `string` | `null` | no |
 | <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | IAM role Force detach policies | `bool` | `false` | no |
 | <a name="input_iam_role_additional_policies"></a> [iam\_role\_additional\_policies](#input\_iam\_role\_additional\_policies) | Additional policies to be added to the IAM role | `map(string)` | `{}` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -32,10 +32,11 @@ variable "dag_s3_path" {
 variable "environment_class" {
   description = <<-EOD
   (Optional) Environment class for the cluster. Possible options are mw1.micro, mw1.small, mw1.medium, mw1.large, mw1.xlarge, mw1.2xlarge.
-  Will be set by default to mw1.micro. Please check the AWS Pricing for more information about the environment classes.
+  Will be set by default to mw1.small. Please check the AWS Pricing for more information about the environment classes.
+  Note: mw1.micro has fixed capacity constraints — schedulers, webservers, and workers must all be set to 1.
   EOD
   type        = string
-  default     = "mw1.micro"
+  default     = "mw1.small"
 
   validation {
     condition     = contains(["mw1.micro", "mw1.small", "mw1.medium", "mw1.large", "mw1.xlarge", "mw1.2xlarge"], var.environment_class)
@@ -61,21 +62,38 @@ variable "logging_configuration" {
 variable "max_workers" {
   description = <<-EOD
   (Optional) The maximum number of workers that can be automatically scaled up.
-  Value need to be between 1 and 25. Will be 10 by default
+  Value need to be between 1 and 25. Will be 10 by default.
+  For mw1.micro environment class, this value must be 1.
   EOD
   type        = number
   default     = 10
 
   validation {
-    condition     = var.max_workers > 0 && var.max_workers < 26
-    error_message = "Error: Value need to be between 1 and 25."
+    condition = (
+      var.environment_class == "mw1.micro"
+      ? var.max_workers == 1
+      : var.max_workers >= 1 && var.max_workers <= 25 && var.max_workers >= var.min_workers
+    )
+    error_message = "Error: For mw1.micro, max_workers must be 1. For other environment classes, value must be between 1 and 25 and >= min_workers."
   }
 }
 
 variable "min_workers" {
-  description = "(Optional) The minimum number of workers that you want to run in your environment. Will be 1 by default."
+  description = <<-EOD
+  (Optional) The minimum number of workers that you want to run in your environment. Will be 1 by default.
+  For mw1.micro environment class, this value must be 1.
+  EOD
   type        = number
   default     = 1
+
+  validation {
+    condition = (
+      var.environment_class == "mw1.micro"
+      ? var.min_workers == 1
+      : var.min_workers >= 1 && var.min_workers <= 25
+    )
+    error_message = "Error: For mw1.micro, min_workers must be 1. For other environment classes, value must be between 1 and 25."
+  }
 }
 
 variable "plugins_s3_object_version" {
@@ -115,14 +133,21 @@ variable "startup_script_s3_path" {
 }
 
 variable "schedulers" {
-  description = "(Optional) The number of schedulers that you want to run in your environment."
+  description = <<-EOD
+  (Optional) The number of schedulers that you want to run in your environment.
+  For mw1.micro environment class, this value must be 1. For other classes, value must be between 2 and 5.
+  EOD
   type        = number
   default     = 2
-  validation {
-    condition     = var.schedulers >= 2 && var.schedulers <= 5
-    error_message = "Error: Value need to be between 2 and 5."
-  }
 
+  validation {
+    condition = (
+      var.environment_class == "mw1.micro"
+      ? var.schedulers == 1
+      : var.schedulers >= 2 && var.schedulers <= 5
+    )
+    error_message = "Error: For mw1.micro, schedulers must be 1. For other environment classes, value must be between 2 and 5."
+  }
 }
 
 variable "webserver_access_mode" {
@@ -137,22 +162,38 @@ variable "webserver_access_mode" {
 }
 
 variable "min_webservers" {
-  description = "(Optional) The minimum number of webserver instances that you want to run in your environment."
+  description = <<-EOD
+  (Optional) The minimum number of webserver instances that you want to run in your environment.
+  For mw1.micro environment class, this value must be 1. For other classes, value must be between 2 and 5.
+  EOD
   type        = number
   default     = 2
+
   validation {
-    condition     = var.min_webservers >= 2 && var.min_webservers <= 5
-    error_message = "Error: Value need to be between 2 and 5."
+    condition = (
+      var.environment_class == "mw1.micro"
+      ? var.min_webservers == 1
+      : var.min_webservers >= 2 && var.min_webservers <= 5
+    )
+    error_message = "Error: For mw1.micro, min_webservers must be 1. For other environment classes, value must be between 2 and 5."
   }
 }
 
 variable "max_webservers" {
-  description = "(Optional) The maximum number of webserver instances that you want to run in your environment."
+  description = <<-EOD
+  (Optional) The maximum number of webserver instances that you want to run in your environment.
+  For mw1.micro environment class, this value must be 1. For other classes, value must be between 2 and 5.
+  EOD
   type        = number
   default     = 2
+
   validation {
-    condition     = (var.max_webservers >= 2 && var.min_webservers <= 5) && (var.max_webservers >= var.min_webservers)
-    error_message = "Error: Value need to be more or equal to `min_webservers` value and be between 2 and 5."
+    condition = (
+      var.environment_class == "mw1.micro"
+      ? var.max_webservers == 1
+      : (var.max_webservers >= 2 && var.max_webservers <= 5) && (var.max_webservers >= var.min_webservers)
+    )
+    error_message = "Error: For mw1.micro, max_webservers must be 1. For other environment classes, value must be between 2 and 5 and >= min_webservers."
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.9.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
### What does this PR do?

Updates variable validations to be environment-class-aware so `mw1.micro` actually works.
Right now the module accepts `mw1.micro` as an environment class but rejects the only valid capacity values (schedulers=1, webservers=1, workers=1) because validations hardcode `>= 2`.

Changes:
- schedulers, min/max_webservers validations allow 1 for mw1.micro, enforce 2-5 otherwise
- max_workers enforces == 1 for micro, added missing >= min_workers cross-check
- min_workers gets a validation (had none)
- environment_class default changed from mw1.micro to mw1.small (defaults were inconsistent)
- required_version bumped to >= 1.9.0 (cross-variable validation needs it)
- README documents micro constraints

### Motivation

Tried using mw1.micro and couldn't — the validations block it. See #86.

### More
- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

terraform-docs and tflint hooks skipped locally (not installed), but fmt and validate passed. Cross-variable validation in validation blocks requires Terraform >= 1.9.0 — note that the existing max_webservers validation already referenced min_webservers, so this was a latent version requirement anyway.
