### PR TITLE
fix: add PUBLIC_AND_PRIVATE to webserver_access_mode validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,14 @@ Apache-2.0 Licensed. See [LICENSE](https://github.com/aws-ia/terraform-aws-mwaa/
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.39.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.39.0 |
 
 ## Modules
@@ -106,7 +106,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_role.mwaa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.mwaa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.mwaa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -128,7 +128,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_additional_principal_arns"></a> [additional\_principal\_arns](#input\_additional\_principal\_arns) | List of additional AWS principal ARNs | `list(string)` | `[]` | no |
 | <a name="input_airflow_configuration_options"></a> [airflow\_configuration\_options](#input\_airflow\_configuration\_options) | (Optional) The airflow\_configuration\_options parameter specifies airflow override options. | `any` | `null` | no |
 | <a name="input_airflow_version"></a> [airflow\_version](#input\_airflow\_version) | (Optional) Airflow version of your environment, will be set by default to the latest version that MWAA supports. | `string` | `null` | no |
@@ -166,13 +166,13 @@ No modules.
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of resource tags to associate with the resource | `map(string)` | `{}` | no |
 | <a name="input_use_source_bucket_name_as_prefix"></a> [use\_source\_bucket\_name\_as\_prefix](#input\_use\_source\_bucket\_name\_as\_prefix) | Whether or not to use the `var.source_bucket_name` as the S3 bucket name prefix | `bool` | `true` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | (Required) VPC ID to deploy the MWAA Environment.<br/>Mandatory if `create_security_group=true` | `string` | `""` | no |
-| <a name="input_webserver_access_mode"></a> [webserver\_access\_mode](#input\_webserver\_access\_mode) | (Optional) Specifies whether the webserver should be accessible over the internet or via your specified VPC. Possible options: PRIVATE\_ONLY (default) and PUBLIC\_ONLY | `string` | `"PRIVATE_ONLY"` | no |
+| <a name="input_webserver_access_mode"></a> [webserver\_access\_mode](#input\_webserver\_access\_mode) | (Optional) Specifies whether the webserver should be accessible over the internet or via your specified VPC. Possible options: PRIVATE\_ONLY (default), PUBLIC\_ONLY and PUBLIC\_AND\_PRIVATE | `string` | `"PRIVATE_ONLY"` | no |
 | <a name="input_weekly_maintenance_window_start"></a> [weekly\_maintenance\_window\_start](#input\_weekly\_maintenance\_window\_start) | (Optional) Specifies the start date for the weekly maintenance window | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_aws_s3_bucket_name"></a> [aws\_s3\_bucket\_name](#output\_aws\_s3\_bucket\_name) | S3 bucket Name of the MWAA Environment |
 | <a name="output_mwaa_arn"></a> [mwaa\_arn](#output\_mwaa\_arn) | The ARN of the MWAA Environment |
 | <a name="output_mwaa_role_arn"></a> [mwaa\_role\_arn](#output\_mwaa\_role\_arn) | IAM Role ARN of the MWAA Environment |

--- a/variables.tf
+++ b/variables.tf
@@ -126,13 +126,13 @@ variable "schedulers" {
 }
 
 variable "webserver_access_mode" {
-  description = "(Optional) Specifies whether the webserver should be accessible over the internet or via your specified VPC. Possible options: PRIVATE_ONLY (default) and PUBLIC_ONLY"
+  description = "(Optional) Specifies whether the webserver should be accessible over the internet or via your specified VPC. Possible options: PRIVATE_ONLY (default), PUBLIC_ONLY and PUBLIC_AND_PRIVATE"
   type        = string
   default     = "PRIVATE_ONLY"
 
   validation {
-    condition     = contains(["PRIVATE_ONLY", "PUBLIC_ONLY"], var.webserver_access_mode)
-    error_message = "Invalid input, options: \"PRIVATE_ONLY\", \"PUBLIC_ONLY\"."
+    condition     = contains(["PRIVATE_ONLY", "PUBLIC_ONLY", "PUBLIC_AND_PRIVATE"], var.webserver_access_mode)
+    error_message = "Invalid input, options: \"PRIVATE_ONLY\", \"PUBLIC_ONLY\", \"PUBLIC_AND_PRIVATE\"."
   }
 }
 


### PR DESCRIPTION
Resolves aws-ia/terraform-aws-mwaa#88


### What does this PR do?

Adds `PUBLIC_AND_PRIVATE` as a valid value for the `webserver_access_mode` variable by updating the validation block and description in `variables.tf`. The `README.md` has also been auto-updated via `terraform_docs`.


### Motivation

The `webserver_access_mode` attribute in the AWS MWAA resource already supports `PUBLIC_AND_PRIVATE` at the provider level (see [hashicorp/terraform-provider-aws#48835](https://github.com/hashicorp/terraform-provider-aws/issues/48835)), but this module's validation block only allowed `PRIVATE_ONLY` and `PUBLIC_ONLY`, causing an error when users attempted to use the new value.


### More
- [ ] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

This is a straightforward validation fix. No logic changes, no new resources. The change aligns the module with the current AWS provider capabilities.

Note: `terraform_tfsec` reports findings during `pre-commit run -a`, but I believe all are pre-existing issues and are unrelated to this change.